### PR TITLE
Deploy to heroku via tags

### DIFF
--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -12,7 +12,7 @@ module Paratrooper
       @formatter     = options[:formatter] || DefaultFormatter.new
       @heroku        = options[:heroku] || HerokuWrapper.new(app_name, options)
       @tag_name      = options[:tag]
-      @deploy_tag    = options[:deploy_tag]
+      @deploy_tag    = options[:deploy_tag] || 'master'
       @system_caller = options[:system_caller] || SystemCaller.new
     end
 
@@ -29,15 +29,14 @@ module Paratrooper
     def update_repo_tag
       unless tag_name.nil? || tag_name.empty?
         notify_screen("Updating Repo Tag: #{tag_name}")
-        system_call "git tag #{tag_name} -f"
+        system_call "git tag #{tag_name} #{deploy_tag} -f"
         system_call "git push origin #{tag_name}"
       end
     end
 
     def push_repo
-      reference = deploy_tag || 'master'
-      notify_screen("Pushing #{reference} to Heroku")
-      system_call "git push -f #{git_remote} #{reference}:master"
+      notify_screen("Pushing #{deploy_tag} to Heroku")
+      system_call "git push -f #{git_remote} #{deploy_tag}:master"
     end
 
     def run_migrations

--- a/spec/paratrooper/deploy_spec.rb
+++ b/spec/paratrooper/deploy_spec.rb
@@ -105,9 +105,22 @@ describe Paratrooper::Deploy do
         deployer.update_repo_tag
       end
 
-      it 'creates a git tag' do
-        system_caller.should_receive(:execute).with('git tag awesome -f')
-        deployer.update_repo_tag
+      context "when deploy_tag is available" do
+        before do
+          options.merge!(deploy_tag: 'deploy_this')
+        end
+
+        it 'creates a git tag at deploy_tag reference point' do
+          system_caller.should_receive(:execute).with('git tag awesome deploy_this -f')
+          deployer.update_repo_tag
+        end
+      end
+
+      context "when no deploy_tag is available" do
+        it 'creates a git tag at HEAD' do
+          system_caller.should_receive(:execute).with('git tag awesome master -f')
+          deployer.update_repo_tag
+        end
       end
 
       it 'pushes git tag' do


### PR DESCRIPTION
Right now we create a tag at master previous to deploy. This was
initially used to track where our apps were at in different
environments. When the deploy happened it was always pulling from
master. I would like to see the deploy happening from a reference
point... like a tag.

Use case:

I tell paratrooper to create a staging tag which will tag current master
and deploy to my staging app.

Then when I tell paratrooper to deploy to the production app I would
like it to create a production tag at the reference point of the staging
tag and also deploy from that point.

This way we don't run into the problem of deploying to production
straight from master. I run master under the assumption that everything
is working but not necessarily confirmed as correct by the client.

Looking for api suggestions

Currently you pass a tag in like so:

``` ruby
Paratrooper::Deploy.new('app', tag: 'staging')
```

Thinking something like this

``` ruby
Paratrooper::Deploy.new('app', tag: 'production', deploy_tag: 'staging')
```
