### PR TITLE
Add callbacks to default deploy actions

### DIFF
--- a/lib/paratrooper/callbacks.rb
+++ b/lib/paratrooper/callbacks.rb
@@ -1,0 +1,67 @@
+require 'forwardable'
+
+module Paratrooper
+  module Callbacks
+    extend Forwardable
+
+    def_delegators :@callbacks, :[], :clear
+
+    HOOKS = %w(activate_maintenance_mode update_repo_tag push_repo run_migrations app_restart deactivate_maintenance_mode warm_instance)
+
+    # Generate alias methods to
+    # all deploy methods
+    #
+    HOOKS.each do |method|
+      class_eval <<-EOF, __FILE__, __LINE__
+        def #{method}_with_callbacks(*args)
+          execute_callbacks_for(:#{method}, :before)
+          #{method}_without_callbacks(*args)
+          execute_callbacks_for(:#{method}, :after)
+        end
+      EOF
+    end
+
+    def self.included(base)
+      HOOKS.each do |method|
+        base.class_eval do
+          alias_method "#{method}_without_callbacks", method
+          alias_method method, "#{method}_with_callbacks"
+        end
+      end
+    end
+
+    # Public: Execute callbacks
+    #
+    # method - Symbol of method that contains callbacks
+    # position - Symbol specifing if :before or :after callbacks
+    def execute_callbacks_for(method, position)
+      return unless callbacks[position][method]
+
+      while callback = callbacks[position][method].shift
+        `#{callback}`
+      end
+    end
+
+    def callbacks
+      @callbacks ||= Hash.new { |h, k| h[k] = {} }
+    end
+
+    # Public: Append callbacks after method
+    #
+    # command - Symbol specified a default deploy method
+    # hook - String with command to be executed
+    def after(command, hook)
+      callbacks[:after][command] ||= []
+      callbacks[:after][command] << hook
+    end
+
+    # Public: Append callbacks before method
+    #
+    # command - Symbol specified a default deploy method
+    # hook - String with command to be executed
+    def before(command, hook)
+      callbacks[:before][command] ||= []
+      callbacks[:before][command] << hook
+    end
+  end
+end

--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -1,6 +1,7 @@
 require 'paratrooper/heroku_wrapper'
 require 'paratrooper/default_formatter'
 require 'paratrooper/system_caller'
+require 'paratrooper/callbacks'
 
 module Paratrooper
 
@@ -131,5 +132,9 @@ module Paratrooper
     def system_call(call)
       system_caller.execute(call)
     end
+
+    # Add callback to default actions for deploy
+    #
+    include Callbacks
   end
 end

--- a/spec/paratrooper/callbacks_spec.rb
+++ b/spec/paratrooper/callbacks_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+require 'paratrooper/callbacks'
+
+describe Paratrooper::Callbacks do
+  class MockDeploy
+    Paratrooper::Callbacks::HOOKS.each do |method|
+      define_method(method){ }
+    end
+
+    def deploy
+      push_repo
+      run_migrations
+    end
+
+    include Paratrooper::Callbacks
+  end
+
+  let(:deploy) { MockDeploy.new }
+
+  describe 'config' do
+    it 'has no callbacks on initiliaze' do
+      deploy.callbacks.empty?.should be_true
+    end
+
+    it 'stores before callbacks' do
+      deploy.before :push_repo, :some_command
+      deploy.callbacks[:before].should == { push_repo: [:some_command] }
+    end
+
+    it 'stores after callbacks' do
+      deploy.after :push_repo, :some_command
+      deploy.callbacks[:after].should == { push_repo: [:some_command] }
+    end
+
+    it 'stores callbacks associated to each method' do
+      deploy.before :push_repo, :some_command
+      deploy.before :push_repo, :other_command
+      deploy.callbacks[:before].should == { push_repo: [:some_command, :other_command] }
+
+      deploy.after :push_repo, :some_command
+      deploy.after :push_repo, :other_command
+      deploy.callbacks[:after].should == { push_repo: [:some_command, :other_command] }
+    end
+  end
+
+  describe 'executing' do
+    before do
+      deploy.stub(:`).and_return([1, 2, 3])
+    end
+
+    it 'callbacks for each method with before' do
+      deploy.should_receive(:`).exactly(2).times.and_return(1, 2)
+      deploy.before :push_repo, "echo '1'"
+      deploy.before :push_repo, "echo '2'"
+      deploy.execute_callbacks_for(:push_repo, :before)
+    end
+
+    it 'callbacks for each method with after' do
+      deploy.should_receive(:`).exactly(2).times.and_return(1, 2)
+      deploy.after :push_repo, "echo '1'"
+      deploy.after :push_repo, "echo '2'"
+      deploy.execute_callbacks_for(:push_repo, :after)
+    end
+
+    it 'execute command between callbacks' do
+      deploy.should_receive(:`).with("echo '1'").ordered
+      deploy.should_receive(:push_repo_without_callbacks).ordered
+      deploy.should_receive(:`).with("echo '2'").ordered
+
+      deploy.before :push_repo, "echo '1'"
+      deploy.after :push_repo, "echo '2'"
+      deploy.push_repo
+    end
+
+    it 'add callback to multiple methods' do
+      deploy.should_receive(:push_repo_without_callbacks).ordered
+      deploy.should_receive(:`).with("echo '1'").ordered
+      deploy.should_receive(:`).with("echo '2'").ordered
+      deploy.should_receive(:run_migrations_without_callbacks).ordered
+
+      deploy.after :push_repo, "echo '1'"
+      deploy.before :run_migrations, "echo '2'"
+      deploy.deploy
+    end
+
+    it 'add all callbacks' do
+      deploy.should_receive(:`).with("echo '1'").ordered
+      deploy.should_receive(:push_repo_without_callbacks).ordered
+      deploy.should_receive(:`).with("echo '2'").ordered
+      deploy.should_receive(:`).with("echo '3'").ordered
+      deploy.should_receive(:run_migrations_without_callbacks).ordered
+      deploy.should_receive(:`).with("echo '4'").ordered
+
+      deploy.before :push_repo, "echo '1'"
+      deploy.after :push_repo, "echo '2'"
+      deploy.before :run_migrations, "echo '3'"
+      deploy.after :run_migrations, "echo '4'"
+      deploy.deploy
+    end
+  end
+end
+


### PR DESCRIPTION
Hi Matt, I wrote some code to add callbacks to default deploy actions.
Now, the user can do:

``` ruby
deployment = Paratrooper::Deploy.new("myapp")
deployment.before :push_repo, "echo 'Hello there' > log.txt"
deployment.deploy
```

I think some points could be improved. Currently, to execute a command I'm using `Kernel#``, and we can just use strings as command line.

What do you think about these?

related to #14
