### PR TITLE
Adds protocol option for warming

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paratrooper (1.1.3)
+    paratrooper (1.2.2)
       heroku-api (~> 0.3)
       netrc (~> 0.7)
 

--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -8,7 +8,7 @@ module Paratrooper
   #
   class Deploy
     attr_reader :app_name, :notifiers, :system_caller, :heroku, :tag_name,
-      :match_tag
+      :match_tag, :protocol
 
     # Public: Initializes a Deploy
     #
@@ -30,6 +30,7 @@ module Paratrooper
       @tag_name      = options[:tag]
       @match_tag     = options[:match_tag_to] || 'master'
       @system_caller = options[:system_caller] || SystemCaller.new
+      @protocol      = options[:protocol] || 'http'
     end
 
     def setup
@@ -97,7 +98,7 @@ module Paratrooper
     def warm_instance(wait_time = 3)
       sleep wait_time
       notify(:warm_instance)
-      system_call "curl -Il http://#{app_url}"
+      system_call "curl -Il #{protocol}://#{app_url}"
     end
 
     # Public: Execute common deploy steps.

--- a/spec/paratrooper/deploy_spec.rb
+++ b/spec/paratrooper/deploy_spec.rb
@@ -53,6 +53,14 @@ describe Paratrooper::Deploy do
         expect(deployer.notifiers).to eq([notifiers])
       end
     end
+    
+    context "accepts :protocol" do
+      let(:options) { { protocol: 'https' } }
+
+      it "and responds to #notifiers" do
+        expect(deployer.protocol).to eq('https')
+      end
+    end
   end
 
   describe "#activate_maintenance_mode" do
@@ -187,6 +195,16 @@ describe Paratrooper::Deploy do
       expected_call = 'curl -Il http://application_url'
       system_caller.should_receive(:execute).with(expected_call)
       deployer.warm_instance(0)
+    end
+    
+    context 'with optional protocol' do
+      let(:options) { { protocol: 'https' } }
+      
+      it 'pings application url using the protocol' do
+        expected_call = 'curl -Il https://application_url'
+        system_caller.should_receive(:execute).with(expected_call)
+        deployer.warm_instance(0)
+      end
     end
   end
 end


### PR DESCRIPTION
The curl call to warm an app instance should use https if the app
requires SSL. This PR adds an optional protocol to Paratrooper::Deploy
that defaults to 'http' and is used by the warm_instance method.
