### PR TITLE
Adds support for AS::Callbacks and smart deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
+
+gem 'heroku-api', '~> 0.3'
+gem 'netrc', '~> 0.7'
+gem 'activesupport', '>= 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,21 @@ PATH
   remote: .
   specs:
     paratrooper (1.2.2)
-      heroku-api (~> 0.3)
-      netrc (~> 0.7)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
+      multi_json (~> 1.0)
     coderay (1.0.8)
     diff-lcs (1.1.3)
     excon (0.16.10)
     heroku-api (0.3.8)
       excon (~> 0.16.10)
+    i18n (0.6.1)
     method_source (0.8.1)
+    multi_json (1.7.2)
     netrc (0.7.7)
     pry (0.9.10)
       coderay (~> 1.0.5)
@@ -34,6 +37,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (>= 3.2.0)
+  heroku-api (~> 0.3)
+  netrc (~> 0.7)
   paratrooper!
   pry
   rake

--- a/lib/paratrooper/callbacks.rb
+++ b/lib/paratrooper/callbacks.rb
@@ -1,0 +1,57 @@
+require 'active_support/callbacks'
+
+module Paratrooper
+  module Callbacks
+    extend ::ActiveSupport::Concern
+    include ::ActiveSupport::Callbacks
+    
+    METHODS = [
+      "setup", "activate_maintenance_mode", "deactivate_maintenance_mode",
+      "update_repo_tag", "push_repo", "run_migrations", "app_restart",
+      "warm_instance", "teardown"
+    ]
+    
+    included do
+      define_callbacks *METHODS + [{:terminator => 'result === false', :scope => [:kind, :name]}]
+      
+      METHODS.each do |method|
+        define_singleton_method "before_#{method}" do |*args, &block|
+          set_callback(method, :before, *args, &block)
+        end
+        
+        define_singleton_method "around_#{method}" do |*args, &block|
+          set_callback(method, :around, *args, &block)
+        end
+        
+        define_singleton_method "after_#{method}" do |*args, &block|
+          options = args.extract_options!
+          options[:prepend] = true
+          options[:if] = Array(options[:if]) << "value != false"
+          set_callback(method, :after, *(args << options), &block)
+        end
+      end
+    end
+    
+    def add_callbacks(callbacks)
+      callbacks.each do |callback|
+        add_callback(callback)
+      end
+    end
+    
+    def add_callback(callback)
+      METHODS.each do |method|
+        add_before_callback(method, callback)
+        add_around_callback(method, callback)
+        add_after_callback(method, callback)
+      end
+    end
+        
+    [:before, :around, :after].each do |kind|
+      define_method("add_#{kind}_callback") do |method, callback|
+        if callback.respond_to? "#{kind}_#{method}".to_sym
+          self.class.set_callback method.to_sym, kind.to_sym, callback
+        end
+      end
+    end
+  end
+end

--- a/lib/paratrooper/callbacks/pending_migrations_callback.rb
+++ b/lib/paratrooper/callbacks/pending_migrations_callback.rb
@@ -1,0 +1,34 @@
+module Paratrooper
+  module Callbacks
+
+    # Public: Optional callback to skip deploy steps unless there are pending
+    # migrations
+    #
+    class PendingMigrationsCallback
+      attr_reader :git_diff
+      
+      def before_activate_maintenance_mode(options = {})
+        return pending_migrations?(options[:tag_name], options[:match_tag])
+      end
+      
+      def before_deactivate_maintenance_mode(options = {})
+        return pending_migrations?(options[:tag_name], options[:match_tag])
+      end
+      
+      def before_run_migrations(options = {})
+        return pending_migrations?(options[:tag_name], options[:match_tag])
+      end
+      
+      def before_app_restart(options = {})
+        return pending_migrations?(options[:tag_name], options[:match_tag])
+      end
+      
+    private
+    
+      def pending_migrations?(tag_name, match_to)
+        @git_diff ||= system_caller.run("git diff --shortstat #{tag_name} #{match_to} db/migrate")
+        !(git_diff.strip.empty?)
+      end
+    end
+  end
+end

--- a/lib/paratrooper/notifier.rb
+++ b/lib/paratrooper/notifier.rb
@@ -1,18 +1,29 @@
+require 'paratrooper/callbacks'
+
 module Paratrooper
 
-  # Public: Shell object with methods to be overridden by other notifiers
+  # Public: Shell object with callback implementations that call
+  # the notifier methods.
   #
   # All notifiers should inherit from this class
   #
   class Notifier
-    def notify(step_name, options = {})
-      self.send(step_name, options)
+    # Set up before callbacks for all available callback
+    # methods which force Notifier classes to behave like
+    # existing notifiers.  Notifiers cannot halt the
+    # execution by returning false because the callbacks
+    # are defined here and always return true.
+    Paratrooper::Callbacks::METHODS.each do |method|
+      define_method("before_#{method}") do |deployer|
+        send(method, deployer.send(:default_payload))
+        return true
+      end
     end
-
+    
     #
     # To create your own notifier override the following methods.
     #
-
+    
     def setup(options = {}); end
     def activate_maintenance_mode(options = {}); end
     def deactivate_maintenance_mode(options = {}); end

--- a/lib/paratrooper/system_caller.rb
+++ b/lib/paratrooper/system_caller.rb
@@ -3,5 +3,9 @@ module Paratrooper
     def execute(call)
       system(call)
     end
+    
+    def run(call)
+      `#{call}`
+    end
   end
 end

--- a/paratrooper.gemspec
+++ b/paratrooper.gemspec
@@ -20,6 +20,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 2.12'
   gem.add_development_dependency 'pry'
-  gem.add_dependency 'heroku-api', '~> 0.3'
-  gem.add_dependency 'netrc', '~> 0.7'
 end

--- a/spec/paratrooper/callbacks_spec.rb
+++ b/spec/paratrooper/callbacks_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'paratrooper/callbacks'
+
+class CallbackTester
+  include Paratrooper::Callbacks
+  
+  before_run_migrations :check_migrations
+  
+  def setup
+    run_callbacks :setup
+  end
+  
+  def run_migrations
+    run_callbacks :run_migrations
+  end
+  
+  def check_migrations; end
+end
+
+class CallbackOne
+  def before_setup; end
+  def before_teardown; end
+end
+
+class CallbackTwo
+  def before_setup; end
+  def before_push_repo; end
+  def after_app_restart; end
+end
+
+describe Paratrooper::Callbacks do
+  let(:callback_tester) { CallbackTester.new }
+  describe '#add_callbacks' do
+    it 'adds a callback for each callback in the array' do
+      callback_one = double
+      callback_two = double
+      callbacks = [callback_one, callback_two]
+      callback_tester.should_receive(:add_callback).with(callback_one)
+      callback_tester.should_receive(:add_callback).with(callback_two)
+      callback_tester.add_callbacks(callbacks)
+    end
+  end
+  
+  describe '#add_callback' do
+    it 'adds before, around, and after callbacks for each method' do
+      callback = double
+      Paratrooper::Callbacks::METHODS.each do |method|
+        callback_tester.should_receive(:add_before_callback).with(method, callback)
+        callback_tester.should_receive(:add_around_callback).with(method, callback)
+        callback_tester.should_receive(:add_after_callback).with(method, callback)
+      end
+      callback_tester.add_callback(callback)
+    end
+  end
+  
+  describe 'adding callbacks' do
+    it 'only adds callbacks that the callback class implements' do
+      callback_one = CallbackOne.new
+      callback_two = CallbackTwo.new
+      CallbackTester.should_receive(:set_callback).with(:setup, :before, callback_one)
+      CallbackTester.should_receive(:set_callback).with(:teardown, :before, callback_one)
+      CallbackTester.should_receive(:set_callback).with(:setup, :before, callback_two)
+      CallbackTester.should_receive(:set_callback).with(:push_repo, :before, callback_two)
+      CallbackTester.should_receive(:set_callback).with(:app_restart, :after, callback_two)
+      callback_tester.add_callbacks([callback_one, callback_two])
+    end
+  end
+  
+  describe 'running callbacks' do
+    it 'runs callbacks appropriately' do
+      callback_one = CallbackOne.new
+      callback_two = CallbackTwo.new
+      callback_tester.add_callbacks([callback_one, callback_two])
+      callback_one.should_receive(:before_setup)
+      callback_two.should_receive(:before_setup)
+      callback_tester.setup
+    end
+  end
+  
+  describe 'callback helpers' do
+    it 'should call callbacks when specified using the callback helper syntax' do
+      callback_tester.should_receive(:check_migrations)
+      callback_tester.run_migrations
+    end
+  end
+end

--- a/spec/paratrooper/deploy_spec.rb
+++ b/spec/paratrooper/deploy_spec.rb
@@ -10,6 +10,7 @@ describe Paratrooper::Deploy do
     {
       heroku: heroku,
       notifiers: [],
+      callbacks: [],
       system_caller: system_caller
     }
   end
@@ -61,11 +62,20 @@ describe Paratrooper::Deploy do
         expect(deployer.protocol).to eq('https')
       end
     end
+    
+    context "accepts :callbacks" do
+      let(:options) { { callbacks: [callbacks] } }
+      let(:callbacks) { double(:callback) }
+    
+      it "and responds to #callbacks" do
+        expect(deployer.callbacks).to eq([callbacks])
+      end
+    end
   end
 
   describe "#activate_maintenance_mode" do
-    it 'sends notification' do
-      deployer.should_receive(:notify).with(:activate_maintenance_mode).once
+    it 'runs callbacks' do
+      deployer.should_receive(:run_callbacks).with(:activate_maintenance_mode).once
       deployer.activate_maintenance_mode
     end
 
@@ -76,8 +86,8 @@ describe Paratrooper::Deploy do
   end
 
   describe "#deactivate_maintenance_mode" do
-    it 'sends notification' do
-      deployer.should_receive(:notify).with(:deactivate_maintenance_mode).once
+    it 'runs callbacks' do
+      deployer.should_receive(:run_callbacks).with(:deactivate_maintenance_mode).once
       deployer.deactivate_maintenance_mode
     end
 
@@ -95,8 +105,8 @@ describe Paratrooper::Deploy do
         system_caller.stub(:execute)
       end
 
-      it 'sends notification' do
-        deployer.should_receive(:notify).with(:update_repo_tag).once
+      it 'runs callbacks' do
+        deployer.should_receive(:run_callbacks).with(:update_repo_tag).once
         deployer.update_repo_tag
       end
 
@@ -139,9 +149,8 @@ describe Paratrooper::Deploy do
       system_caller.stub(:execute)
     end
 
-    it 'sends notification' do
-      deployer.should_receive(:notify)
-        .with(:push_repo, reference_point: 'master').once
+    it 'runs callbacks' do
+      deployer.should_receive(:run_callbacks).with(:push_repo).once
       deployer.push_repo
     end
 
@@ -157,8 +166,8 @@ describe Paratrooper::Deploy do
       system_caller.stub(:execute)
     end
 
-    it 'sends notification' do
-      deployer.should_receive(:notify).with(:run_migrations).once
+    it 'runs callbacks' do
+      deployer.should_receive(:run_callbacks).with(:run_migrations).once
       deployer.run_migrations
     end
 
@@ -170,8 +179,8 @@ describe Paratrooper::Deploy do
   end
 
   describe "#app_restart" do
-    it 'sends notification' do
-      deployer.should_receive(:notify).with(:app_restart).once
+    it 'runs callbacks' do
+      deployer.should_receive(:run_callbacks).with(:app_restart).once
       deployer.app_restart
     end
 
@@ -186,8 +195,8 @@ describe Paratrooper::Deploy do
       system_caller.stub(:execute)
     end
 
-    it 'sends notification' do
-      deployer.should_receive(:notify).with(:warm_instance).once
+    it 'runs callbacks' do
+      deployer.should_receive(:run_callbacks).with(:warm_instance).once
       deployer.warm_instance(0)
     end
 

--- a/spec/paratrooper/notifier_spec.rb
+++ b/spec/paratrooper/notifier_spec.rb
@@ -3,10 +3,20 @@ require 'paratrooper/notifier'
 
 describe Paratrooper::Notifier do
   let(:notifier) { described_class.new }
-  describe '#notify' do
-    it 'sends correct method options' do
-      notifier.should_receive(:update_repo_tag).with(test: 'blah')
-      notifier.notify(:update_repo_tag, test: 'blah')
+  
+  describe '#callbacks' do
+    Paratrooper::Callbacks::METHODS.each do |method|
+      it { should respond_to(method.to_sym) }
+      it "should return true from the before_#{method} callback" do
+        expect(notifier.send("before_#{method}", double(:default_payload => nil))).to be_true
+      end
+    end
+    
+    it 'should send the default payload into the notifier method' do
+      payload = {'test' => 'value'}
+      deployer = double(:default_payload => payload)
+      notifier.should_receive(:setup).with(payload)
+      notifier.before_setup(deployer)
     end
   end
 end


### PR DESCRIPTION
This commit adds support for ActiveSupport::Callbacks to the
Paratrooper::Deploy class. All deploy methods trigger callbacks.

The Paratrooper Notifier concept has been refactored a bit to make use
of Callbacks. This was done without actually requiring any changes to
existing Notifiers that inherit from Paratrooper::Notifier.

An additional Paratrooper::Deploy option has been added to specify
callbacks directly. Callbacks differ from Notifiers only in that
they do not need to inherit from Notifier and can alter deploy
step execution.
