### PR TITLE
Add ssh_host option with specs and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ This method works via a local Netrc file handled via the [Heroku Toolbelt][] and
 
 ## Git SSH key configuration
 
-If you use multiple SSH keys for managing multiple accounts, for example in your `.ssh/config`, you can set the `host` option:
+If you use multiple SSH keys for managing multiple accounts, for example in your `.ssh/config`, you can set the `ssh_host` option:
 
 ```ruby
-Paratrooper::Deploy.new('app', host: 'HOST')
+Paratrooper::Deploy.new('app', ssh_host: 'HOST')
 ```
 
 This also works if you're using the [heroku-accounts](https://github.com/ddollar/heroku-accounts) plugin:
 
 ```ruby
-Paratrooper::Deploy.new('app', host: 'heroku.ACCOUNT_NAME')
+Paratrooper::Deploy.new('app', ssh_host: 'heroku.ACCOUNT_NAME')
 ```
 
 ## Tag Management

--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -8,7 +8,7 @@ module Paratrooper
   #
   class Deploy
     attr_reader :app_name, :notifiers, :system_caller, :heroku, :tag_name,
-      :match_tag, :protocol, :host
+      :match_tag, :protocol, :ssh_host
 
     # Public: Initializes a Deploy
     #
@@ -25,8 +25,8 @@ module Paratrooper
     #                             commands (optional).
     #            :protocol      - String web protocol to be used when pinging
     #                             application (optional, default: 'http').
-    #            :host          - String host to be used in git URL (optional,
-    #                             default: 'heroku.com').
+    #            :ssh_host      - String SSH host name to be used in git URL
+    #                             (optional, default: 'heroku.com').
     def initialize(app_name, options = {})
       @app_name      = app_name
       @notifiers     = options[:notifiers] || [Notifiers::ScreenNotifier.new]
@@ -35,7 +35,7 @@ module Paratrooper
       @match_tag     = options[:match_tag_to] || 'master'
       @system_caller = options[:system_caller] || SystemCaller.new
       @protocol      = options[:protocol] || 'http'
-      @host          = options[:host] || 'heroku.com'
+      @ssh_host      = options[:ssh_host] || 'heroku.com'
     end
 
     def setup
@@ -147,7 +147,7 @@ module Paratrooper
     end
 
     def git_remote
-      "git@#{host}:#{app_name}.git"
+      "git@#{ssh_host}:#{app_name}.git"
     end
 
     # Internal: Calls commands meant to go to system

--- a/spec/paratrooper/deploy_spec.rb
+++ b/spec/paratrooper/deploy_spec.rb
@@ -62,11 +62,11 @@ describe Paratrooper::Deploy do
       end
     end
 
-    context "accepts :host" do
-      let(:options) { { host: 'host_name' } }
+    context "accepts :ssh_host" do
+      let(:options) { { ssh_host: 'host_name' } }
 
       it "and responds to #notifiers" do
-        expect(deployer.host).to eq('host_name')
+        expect(deployer.ssh_host).to eq('host_name')
       end
     end
   end


### PR DESCRIPTION
Added support for custom hosts in git URL [Issue #26](https://github.com/mattpolito/paratrooper/issues/26), for example `git@heroku.ACCOUNT_NAME:APP`.

This option allows one to use paratrooper with the heroku-accounts plugin or with any custom host/ssh pair.

I added specs and manually tested this by pushing to Heroku myself in a project using the heroku-accounts plugin. Works as expected!
