### PR TITLE
Change rubygems source to secure URL in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       netrc (~> 0.7)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     coderay (1.0.8)
     diff-lcs (1.1.3)


### PR DESCRIPTION
Was getting the warning: `The source :rubygems is deprecated because HTTP requests are insecure.`

Updated the source to the proper secure URL.
