### PR TITLE
Explicitly pushing repo to heroku master ref

### DIFF
--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -87,7 +87,7 @@ module Paratrooper
     def push_repo
       reference_point = tag_name || 'master'
       notify(:push_repo, reference_point: reference_point)
-      system_call "git push -f #{deployment_remote} #{reference_point}:master"
+      system_call "git push -f #{deployment_remote} #{reference_point}:refs/heads/master"
     end
 
     # Public: Runs rails database migrations on your application.

--- a/spec/paratrooper/deploy_spec.rb
+++ b/spec/paratrooper/deploy_spec.rb
@@ -168,7 +168,7 @@ describe Paratrooper::Deploy do
     end
 
     it 'pushes repo to heroku' do
-      expected_call = 'git push -f git@heroku.com:app.git master:master'
+      expected_call = 'git push -f git@heroku.com:app.git master:refs/heads/master'
       system_caller.should_receive(:execute).with(expected_call)
       deployer.push_repo
     end


### PR DESCRIPTION
This will remove the ambiguity of pushing to 'master'

[fixes #22]

https://github.com/mattpolito/paratrooper/issues/22
