### PR TITLE
Wrapping maintenance mode around migrations

### DIFF
--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -183,7 +183,6 @@ module Paratrooper
       push_repo
       maintenance_mode do
         run_migrations
-        app_restart
       end
       warm_instance
       teardown


### PR DESCRIPTION
When migrations actually need to be run, there is no need to keep the
app down for the entire deploy

[address #54]
