### PR TITLE
Memoize pending migration check git diff

### DIFF
--- a/lib/paratrooper/pending_migration_check.rb
+++ b/lib/paratrooper/pending_migration_check.rb
@@ -11,9 +11,10 @@ module Paratrooper
     end
 
     def migrations_waiting?
+      return @migrations_waiting unless @migrations_waiting.nil?
       call = %Q[git diff --shortstat #{last_deployed_commit} #{match_tag_name} -- db/migrate]
       self.diff = system_caller.execute(call)
-      !diff.strip.empty?
+      @migrations_waiting = !diff.strip.empty?
     end
 
     def last_deployed_commit

--- a/spec/paratrooper/pending_migration_check_spec.rb
+++ b/spec/paratrooper/pending_migration_check_spec.rb
@@ -21,6 +21,11 @@ describe Paratrooper::PendingMigrationCheck do
       migration_check.migrations_waiting?
     end
 
+    it "memoizes the git diff" do
+      system_caller.should_receive(:execute).exactly(1).times.and_return("DIFF")
+      migration_check.migrations_waiting?
+    end
+
     context "and migrations are in diff" do
       it "returns true" do
         expected_call = %Q[git diff --shortstat LAST_DEPLOYED_COMMIT MATCH -- db/migrate]


### PR DESCRIPTION
Very basic change to memoize the system call to `git diff` as we would not expect this value to change for the lifetime of a given instance of a PendingMigrationCheck.

The git diff is not very time-consuming but I know when I was writing some callbacks tonight I was worried about the timing of reaching in and checking `deploy.migration_check.migrations_waiting?`.  I expected this value to be memoized somewhere so that callbacks after migrations ran would still have a true value for this method call.

After digging in a bit more of course I realized that the way the git diff is constructed it does not actually matter if the value is memoized but the fact that it was not confused me at first and caused me to dig more than I needed to.

This change would have prevented me from questioning the timeline of making multiple calls to the the PendingMigrationCheck _and_ should be a (tiny?) bit more efficient.
