### PR TITLE
Don’t show maintenance page by default

### DIFF
--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -14,7 +14,7 @@ module Paratrooper
 
     attr_accessor :app_name, :notifiers, :system_caller, :heroku, :tag_name,
       :match_tag_name, :protocol, :deployment_host, :migration_check, :debug,
-      :screen_notifier, :branch_name, :http_client
+      :screen_notifier, :branch_name, :http_client, :maintenance
 
     alias_method :tag=, :tag_name=
     alias_method :match_tag=, :match_tag_name=
@@ -46,6 +46,9 @@ module Paratrooper
     #                               (optional, default: 'heroku.com').
     #            :migration_check - Object responsible for checking pending
     #                               migrations (optional).
+    #            :maintenance     - If true, show maintenance page when pending
+    #                               migrations exists. False by default (optional).
+    #                               migrations (optional).
     #            :api_key         - String version of heroku api key.
     #                               (default: looks in local Netrc file).
     #            :http_client     - Object responsible for making http calls
@@ -65,6 +68,7 @@ module Paratrooper
       @debug           = options[:debug] || false
       @migration_check = options[:migration_check] || PendingMigrationCheck.new(match_tag_name, heroku, system_caller)
       @http_client     = options[:http_client] || HttpClientWrapper.new
+      @maintenance     = options[:maintenance] || false
 
       block.call(self) if block_given?
     end
@@ -89,7 +93,7 @@ module Paratrooper
     # Public: Activates Heroku maintenance mode.
     #
     def activate_maintenance_mode
-      return unless pending_migrations?
+      return unless maintenance && pending_migrations?
       callback(:activate_maintenance_mode) do
         notify(:activate_maintenance_mode)
         heroku.app_maintenance_on

--- a/spec/paratrooper/deploy_spec.rb
+++ b/spec/paratrooper/deploy_spec.rb
@@ -127,8 +127,8 @@ describe Paratrooper::Deploy do
   end
 
   describe "#activate_maintenance_mode" do
-    context "when maintenance_mode option is 'true'" do
-      let(:options) { { maintenance_mode: true } }
+    context "when maintenance option is 'true'" do
+      let(:options) { { maintenance: true } }
 
       context "with pending migrations" do
         before do
@@ -160,6 +160,42 @@ describe Paratrooper::Deploy do
           heroku.should_not_receive(:app_maintenance_on)
           deployer.activate_maintenance_mode
         end
+      end
+    end
+
+    context "when maintenance option is false" do
+      let(:options) { { maintenance: false } }
+
+      before do
+        migration_check.stub(:migrations_waiting?).and_return(true)
+      end
+
+      it 'does not send notification' do
+        deployer.should_not_receive(:notify).with(:activate_maintenance_mode)
+        deployer.activate_maintenance_mode
+      end
+
+      it "does not make a call to heroku to turn on maintenance mode" do
+        heroku.should_not_receive(:app_maintenance_on)
+        deployer.activate_maintenance_mode
+      end
+    end
+
+    context "when maintenance option is left as default" do
+      let(:options) { { } }
+
+      before do
+        migration_check.stub(:migrations_waiting?).and_return(true)
+      end
+
+      it 'does not send notification' do
+        deployer.should_not_receive(:notify).with(:activate_maintenance_mode)
+        deployer.activate_maintenance_mode
+      end
+
+      it "does not make a call to heroku to turn on maintenance mode" do
+        heroku.should_not_receive(:app_maintenance_on)
+        deployer.activate_maintenance_mode
       end
     end
   end


### PR DESCRIPTION
Following discussion on https://github.com/mattpolito/paratrooper/issues/54, most migrations are quick enough not to need to show the maintenance page. 

So… don’t bother showing maintenance by default, but allow users to pass in an option if they specifically need to show maintenance.

What do you think @mattpolito?
