### PR TITLE
Support deploying from current branch (HEAD)

### DIFF
--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -37,7 +37,8 @@ module Paratrooper
     #            :match_tag       - String name of git reference point to match
     #                               :tag to (optional).
     #            :branch          - String name to be used as a git reference
-    #                               point for deploying from specific branch
+    #                               point for deploying from specific branch.
+    #                               Use :head to deploy from current branch
     #                               (optional).
     #            :force           - Force deploy using (-f flag) on deploy
     #                               (optional, default: false)
@@ -240,7 +241,9 @@ module Paratrooper
     end
 
     def git_branch_name
-      "refs/heads/#{branch_name}" if branch_name
+      if branch_name
+        branch_name == :head ? "HEAD" : "refs/heads/#{branch_name}"
+      end
     end
 
     def git_tag_name

--- a/spec/paratrooper/deploy_spec.rb
+++ b/spec/paratrooper/deploy_spec.rb
@@ -307,12 +307,16 @@ describe Paratrooper::Deploy do
     end
 
     context "when branch_name is available" do
-      before do
+      it 'pushes branch_name to heroku' do
         deployer.branch_name = "BRANCH_NAME"
+        expected_call = 'git push git@heroku.com:app.git refs/heads/BRANCH_NAME:refs/heads/master'
+        system_caller.should_receive(:execute).with(expected_call)
+        deployer.push_repo
       end
 
-      it 'pushes branch_name to heroku' do
-        expected_call = 'git push git@heroku.com:app.git refs/heads/BRANCH_NAME:refs/heads/master'
+      it 'supports pushing to HEAD (current branch)' do
+        deployer.branch_name = :head
+        expected_call = 'git push git@heroku.com:app.git HEAD:refs/heads/master'
         system_caller.should_receive(:execute).with(expected_call)
         deployer.push_repo
       end


### PR DESCRIPTION
Create from https://github.com/mattpolito/paratrooper/pull/64. There is some initial discussion on that PR. This PR isolates the issue.

This makes sense to me as the default. If you want a fixed branch, simply set it with `branch: 'master'`. Obviously this change is backward incompatible so it may require a major version release.

If it is decided that the default should remain to master, I'll force push an update that keeps master as the default but allow for the config option of `branch = :head`. Let me know.
