### PR TITLE
Begin HerokuWrapper upgrade to Heroku API v3

### DIFF
--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -44,15 +44,15 @@ module Paratrooper
 
     def run_task(task)
       payload = { 'command' => task, 'attach' => 'true' }
-      data    = client(:dyno, :create, app_name, payload).body
-      rendezvous.start(url: data['rendezvous_url'])
+      data    = client(:dyno, :create, app_name, payload)
+      rendezvous.start(url: data['attach_url'])
     end
 
     def last_deploy_commit
-      last_release = releases.body.first
+      last_release = releases.first
       return nil if last_release.nil?
 
-      slug_data = client(:slug, :info, app_name, get_slug_id(last_release)).body
+      slug_data = client(:slug, :info, app_name, get_slug_id(last_release))
       slug_data.last['commit']
     end
 

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -42,8 +42,9 @@ module Paratrooper
       run_task('rake db:migrate')
     end
 
-    def run_task(task_name)
-      data = client(:post_ps, app_name, task_name, attach: 'true').body
+    def run_task(task)
+      payload = { 'command' => task, 'attach' => 'true' }
+      data    = client(:dyno, :create, app_name, payload).body
       rendezvous.start(url: data['rendezvous_url'])
     end
 

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -51,7 +51,7 @@ module Paratrooper
     def last_deploy_commit
       return nil if last_release_with_slug.nil?
       slug_data = client(:slug, :info, app_name, get_slug_id(last_release_with_slug))
-      slug_data.last['commit']
+      slug_data['commit']
     end
 
     def last_release_with_slug

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -70,7 +70,7 @@ module Paratrooper
 
     def client(delegatee, method, *args)
       heroku_api.public_send(delegatee).public_send(method, *args)
-    rescue PlatformAPI::Excon::Errors::Forbidden => e
+    rescue Excon::Errors::Forbidden => e
       raise ErrorNoAccess.new(app_name)
     end
   end

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -64,10 +64,6 @@ module Paratrooper
       release["slug"]["id"]
     end
 
-    def app_maintenance(flag)
-      client(:post_app_maintenance, app_name, flag)
-    end
-
     def client(delegatee, method, *args)
       heroku_api.public_send(delegatee).public_send(method, *args)
     rescue Excon::Errors::Forbidden => e

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -1,4 +1,4 @@
-require 'heroku-api'
+require 'platform-api'
 require 'rendezvous'
 require 'paratrooper/local_api_key_extractor'
 require 'paratrooper/error'

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -49,17 +49,15 @@ module Paratrooper
     end
 
     def last_deploy_commit
-      last_release = releases.first
-      return nil if last_release.nil?
-
-      slug_data = client(:slug, :info, app_name, get_slug_id(last_release))
+      return nil if releases.empty?
+      slug_data = client(:slug, :info, app_name, get_slug_id(releases.first))
       slug_data.last['commit']
     end
 
     private
 
-    def get_slug_id(release)
-      release["slug"]["id"].to_i
+    def get_slug_id(last_release)
+      last_release["slug"]["id"].to_i
     end
 
     def app_maintenance(flag)

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -61,7 +61,7 @@ module Paratrooper
     private
 
     def get_slug_id(release)
-      release["slug"]["id"].to_i
+      release["slug"]["id"]
     end
 
     def app_maintenance(flag)

--- a/lib/paratrooper/heroku_wrapper.rb
+++ b/lib/paratrooper/heroku_wrapper.rb
@@ -35,7 +35,7 @@ module Paratrooper
     end
 
     def releases
-      client(:release, :list, app_name)
+      @releases ||= client(:release, :list, app_name)
     end
 
     def run_migrations
@@ -49,15 +49,19 @@ module Paratrooper
     end
 
     def last_deploy_commit
-      return nil if releases.empty?
-      slug_data = client(:slug, :info, app_name, get_slug_id(releases.first))
+      return nil if last_release_with_slug.nil?
+      slug_data = client(:slug, :info, app_name, get_slug_id(last_release_with_slug))
       slug_data.last['commit']
+    end
+
+    def last_release_with_slug
+      releases.reverse.detect { |release| not release['slug'].nil? }
     end
 
     private
 
-    def get_slug_id(last_release)
-      last_release["slug"]["id"].to_i
+    def get_slug_id(release)
+      release["slug"]["id"].to_i
     end
 
     def app_maintenance(flag)

--- a/paratrooper.gemspec
+++ b/paratrooper.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'pry'
-  gem.add_dependency 'heroku-api', '~> 0.3'
+  gem.add_dependency 'platform-api', '~> 0.2'
   gem.add_dependency 'rendezvous', '~> 0.1'
   gem.add_dependency 'netrc', '~> 0.7'
   gem.add_dependency 'excon', '>= 0.44.4'

--- a/spec/paratrooper/heroku_wrapper_spec.rb
+++ b/spec/paratrooper/heroku_wrapper_spec.rb
@@ -89,7 +89,7 @@ describe Paratrooper::HerokuWrapper do
       end
 
       it "returns string of last deployed commit" do
-        slug_info = release_data.first["slug"]["id"].to_i
+        slug_info = release_data.first["slug"]["id"]
 
         allow(heroku_api).to receive_message_chain(:release, :list).and_return(release_data)
         expect(heroku_api).to receive_message_chain(:slug, :info).with(app_name, slug_info)

--- a/spec/paratrooper/heroku_wrapper_spec.rb
+++ b/spec/paratrooper/heroku_wrapper_spec.rb
@@ -116,6 +116,33 @@ describe Paratrooper::HerokuWrapper do
     end
   end
 
+  describe '#last_release_with_slug' do
+    let(:releases) do
+      [
+        { 'slug' => { 'id' => '1' }, 'updated_at' => '1990' },
+        { 'slug' => { 'id' => '2' }, 'updated_at' => '2015' },
+        { 'slug' => nil }
+      ]
+    end
+    it 'returns the most current release that has a slug attribute' do
+      allow(heroku_api).to receive_message_chain(:release, :list).and_return(releases)
+      expect(wrapper.last_release_with_slug['updated_at']).to eq '2015'
+
+    end
+
+    it 'returns nil if none of the releases have a slug attribute' do
+      data = [{ 'slug' => nil }]
+      allow(heroku_api).to receive_message_chain(:release, :list).and_return(data)
+      expect(wrapper.last_release_with_slug).to be_nil
+    end
+
+    it 'returns nil if the releases array is empty' do
+      data = []
+      allow(heroku_api).to receive_message_chain(:release, :list).and_return(data)
+      expect(wrapper.last_release_with_slug).to be_nil
+    end
+  end
+
   describe "#run_task" do
     it 'calls into the heroku api' do
       task = 'rake some:task:to:run'

--- a/spec/paratrooper/heroku_wrapper_spec.rb
+++ b/spec/paratrooper/heroku_wrapper_spec.rb
@@ -81,7 +81,7 @@ describe Paratrooper::HerokuWrapper do
   describe "#last_deploy_commit" do
     context "when deploy data is returned" do
       let(:slug_data) do
-        [{ 'commit' => 'SHA' }]
+        { 'commit' => 'SHA' }
       end
 
       let(:release_data) do

--- a/spec/paratrooper/heroku_wrapper_spec.rb
+++ b/spec/paratrooper/heroku_wrapper_spec.rb
@@ -65,14 +65,14 @@ describe Paratrooper::HerokuWrapper do
   end
 
   describe '#run_migrations' do
-    xit 'calls into the heroku api' do
-      expect(heroku_api).to receive(:post_ps).with(app_name, 'rake db:migrate', attach: 'true').and_return(double(body: ''))
+    it 'calls into the heroku api' do
+      expect(heroku_api).to receive_message_chain(:dyno, :create).with(app_name, {'command' => 'rake db:migrate', 'attach' => 'true' }).and_return(double(body: ''))
       wrapper.run_migrations
     end
 
-    xit 'uses waits for db migrations to run using rendezvous' do
+    it 'uses waits for db migrations to run using rendezvous' do
       data = { 'rendezvous_url' => 'the_url' }
-      allow(heroku_api).to receive_message_chain(:post_ps, :body).and_return(data)
+      allow(heroku_api).to receive_message_chain(:dyno, :create).with(app_name, {'command' => 'rake db:migrate', 'attach' => 'true' }).and_return(double(body: data))
       expect(rendezvous).to receive(:start).with(:url => data['rendezvous_url'])
       wrapper.run_migrations
     end
@@ -117,9 +117,9 @@ describe Paratrooper::HerokuWrapper do
   end
 
   describe "#run_task" do
-    xit 'calls into the heroku api' do
+    it 'calls into the heroku api' do
       task = 'rake some:task:to:run'
-      expect(heroku_api).to receive(:post_ps).with(app_name, task, attach: 'true').and_return(double(body: ''))
+      expect(heroku_api).to receive_message_chain(:dyno, :create).with(app_name, {'command' => task, 'attach' => 'true' }).and_return(double(body: ''))
       wrapper.run_task(task)
     end
   end


### PR DESCRIPTION
Hey Matt:

I went ahead and began upgrading the HerokuWrapper to the v3 version of the Heroku API ([PlatformAPI](https://github.com/heroku/platform-api)). Issue: https://github.com/mattpolito/paratrooper/issues/78

It's mostly in-place.....but I couldn't find any endpoints in the v3 API that would support running custom rake commands. Similar to: `heroku run rake db:migrate`

In v2 of the API, you can find how this was supported on line 14 of https://github.com/heroku/heroku.rb/blob/master/lib/heroku/api/processes.rb

Without support in the v3 API (that I could find), I couldn't upgrade the functionality for:
**HerokuWrapper#run_migrations** 
**HerokuWrapper#run_task**

I went ahead and made the tests for those methods pending, for whenever this gets figured out.

Cheers!
Joshua Plicque
