### PR TITLE
Refactor PendingMigrationCheck

### DIFF
--- a/lib/paratrooper/configuration.rb
+++ b/lib/paratrooper/configuration.rb
@@ -30,7 +30,7 @@ module Paratrooper
     end
 
     def migration_check
-      @migration_check ||= PendingMigrationCheck.new(source_control.deployment_sha, heroku, system_caller)
+      @migration_check ||= PendingMigrationCheck.new(heroku.last_deployed_commit, source_control.deployment_sha, system_caller)
     end
 
     def heroku

--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -62,7 +62,6 @@ module Paratrooper
     def setup
       callback(:setup) do
         notify(:setup)
-        migration_check.last_deployed_commit
       end
     end
 

--- a/lib/paratrooper/pending_migration_check.rb
+++ b/lib/paratrooper/pending_migration_check.rb
@@ -2,10 +2,10 @@ require 'paratrooper/system_caller'
 
 module Paratrooper
   class PendingMigrationCheck
-    attr_accessor :diff, :heroku, :deployment_sha, :system_caller
+    attr_accessor :diff, :last_deployed_commit, :deployment_sha, :system_caller
 
-    def initialize(deployment_sha, heroku_wrapper, system_caller)
-      self.heroku         = heroku_wrapper
+    def initialize(last_deployed_commit, deployment_sha, system_caller)
+      self.last_deployed_commit = last_deployed_commit
       self.deployment_sha = deployment_sha
       self.system_caller  = system_caller
     end
@@ -13,10 +13,6 @@ module Paratrooper
     def migrations_waiting?
       defined?(@migrations_waiting) or @migrations_waiting = check_for_pending_migrations
       @migrations_waiting
-    end
-
-    def last_deployed_commit
-      @last_deploy_commit ||= heroku.last_deploy_commit
     end
 
     private

--- a/spec/paratrooper/configuration_spec.rb
+++ b/spec/paratrooper/configuration_spec.rb
@@ -219,14 +219,15 @@ describe Paratrooper::Configuration do
       it "returns the default pending migration check object" do
         migration_check_class = class_double("PendingMigrationCheck")
         stub_const("Paratrooper::PendingMigrationCheck", migration_check_class)
-        migration_check = double(:heroku)
+        heroku = double(:heroku, last_deployed_commit: "LAST_DEPLOYED_COMMIT")
+        migration_check = double(:migration_check)
         source_control = double(:source_control, deployment_sha: "SHA")
 
-        configuration.heroku = "HEROKU"
+        configuration.heroku = heroku
         configuration.system_caller = "SYSTEM"
         configuration.source_control = source_control
 
-        expect(migration_check_class).to receive(:new).with("SHA", "HEROKU", "SYSTEM")
+        expect(migration_check_class).to receive(:new).with("LAST_DEPLOYED_COMMIT", "SHA", "SYSTEM")
           .and_return(migration_check)
         expect(configuration.migration_check).to eq(migration_check)
       end

--- a/spec/paratrooper/pending_migration_check_spec.rb
+++ b/spec/paratrooper/pending_migration_check_spec.rb
@@ -3,23 +3,14 @@ require 'paratrooper/pending_migration_check'
 
 describe Paratrooper::PendingMigrationCheck do
   let(:migration_check) do
-    described_class.new(match_tag_name, heroku_wrapper, system_caller)
+    described_class.new(last_deployed_commit, match_tag_name, system_caller)
   end
   let(:system_caller) { double(:system_caller) }
-  let(:heroku_wrapper) do
-    double(:heroku_wrapper, last_deploy_commit: last_deployed_commit)
-  end
   let(:last_deployed_commit) { nil }
 
   describe "#migrations_waiting?" do
     let(:match_tag_name) { "MATCH" }
     let(:last_deployed_commit) { "LAST_DEPLOYED_COMMIT" }
-
-    it "calls out to heroku for latest deploy's commit" do
-      allow(system_caller).to receive(:execute).and_return("")
-      expect(heroku_wrapper).to receive(:last_deploy_commit)
-      migration_check.migrations_waiting?
-    end
 
     it "memoizes the git diff" do
       expect(system_caller).to receive(:execute).exactly(1).times.and_return("DIFF")


### PR DESCRIPTION
Refactor PendingMigrationCheck so that #last_deployed_commit is an input
instead of lookup.  This simplifies PendingMigrationCheck and allows
users of the configuration option `migration_check` to have a simpler
interface to implement.