### PR TITLE
Adds configuration option for remote name

### DIFF
--- a/lib/paratrooper/configuration.rb
+++ b/lib/paratrooper/configuration.rb
@@ -13,7 +13,7 @@ module Paratrooper
     attr_accessor :branch_name, :tag_name, :match_tag_name, :app_name, :api_key
     attr_writer :protocol, :heroku, :migration_check,
       :system_caller, :deployment_host, :http_client, :screen_notifier,
-      :source_control
+      :source_control, :remote_name
 
     alias :branch= :branch_name=
     alias :tag= :tag_name=
@@ -92,6 +92,10 @@ module Paratrooper
 
     def source_control
       @source_control ||= SourceControl.new(self)
+    end
+
+    def remote_name
+      @remote_name ||= app_name
     end
   end
 end

--- a/lib/paratrooper/deploy.rb
+++ b/lib/paratrooper/deploy.rb
@@ -47,6 +47,8 @@ module Paratrooper
     #                               (default: looks in local Netrc file).
     #            :http_client     - Object responsible for making http calls
     #                               (optional).
+    #            :remote_name     - Name of the remote repository
+    #                               (optional, default: app_name).
     #
     def initialize(app_name, options = {}, &block)
       config.attributes = options.merge(app_name: app_name)

--- a/lib/paratrooper/source_control.rb
+++ b/lib/paratrooper/source_control.rb
@@ -12,7 +12,7 @@ module Paratrooper
     end
 
     def remote
-      "git@#{config.deployment_host}:#{config.app_name}.git"
+      "git@#{config.deployment_host}:#{config.remote_name}.git"
     end
 
     def branch_name

--- a/spec/paratrooper/configuration_spec.rb
+++ b/spec/paratrooper/configuration_spec.rb
@@ -369,4 +369,20 @@ describe Paratrooper::Configuration do
       expect(configuration.branch_name).to eq("BRANCH_NAME")
     end
   end
+
+  describe "remote_name" do
+    context "with passed value" do
+      it "returns passed value" do
+        configuration.remote_name = "REMOTE_NAME"
+        expect(configuration.remote_name).to eq("REMOTE_NAME")
+      end
+    end
+
+    context "with no value passed" do
+      it "returns app_name" do
+        configuration.app_name = "APP_NAME"
+        expect(configuration.remote_name).to eq("APP_NAME")
+      end
+    end
+  end
 end

--- a/spec/paratrooper/source_control_spec.rb
+++ b/spec/paratrooper/source_control_spec.rb
@@ -6,11 +6,24 @@ describe Paratrooper::SourceControl do
   describe "remote" do
     it "returns string of git representing remote repo" do
       config = instance_double(Paratrooper::Configuration,
-        deployment_host: 'HOST', app_name: 'APP'
+        deployment_host: 'HOST', app_name: 'APP', remote_name: 'APP'
       )
+
+      # expect(config).to receive(:remote_name).and_return('APP')
+
       source_control = described_class.new(config)
 
       expect(source_control.remote).to eq("git@HOST:APP.git")
+    end
+
+    it "returns string of git representing remote repo using the remote name" do
+      config = instance_double(Paratrooper::Configuration,
+        deployment_host: 'HOST', remote_name: 'REMOTE_NAME'
+      )
+
+      source_control = described_class.new(config)
+
+      expect(source_control.remote).to eq("git@HOST:REMOTE_NAME.git")
     end
   end
 
@@ -156,7 +169,7 @@ describe Paratrooper::SourceControl do
     context "when branch_name is a string" do
       it 'pushes branch_name' do
         config = instance_double(Paratrooper::Configuration, force_push: false,
-          deployment_host: "HOST", app_name: "APP", branch_name?: true,
+          deployment_host: "HOST", app_name: "APP", remote_name: "APP", branch_name?: true,
           branch_name: "BRANCH_NAME", tag_name: nil,
           system_caller: system_caller
         )
@@ -171,7 +184,7 @@ describe Paratrooper::SourceControl do
     context "when branch_name is a symbol" do
       it 'pushes branch_name' do
         config = instance_double(Paratrooper::Configuration, force_push: false,
-          deployment_host: "HOST", app_name: "APP", branch_name?: true,
+          deployment_host: "HOST", app_name: "APP", remote_name: "APP", branch_name?: true,
           branch_name: :BRANCH_NAME, tag_name: nil,
           system_caller: system_caller
         )
@@ -186,7 +199,7 @@ describe Paratrooper::SourceControl do
     context "when branch_name is :head" do
       it 'pushes HEAD' do
         config = instance_double(Paratrooper::Configuration, force_push: false,
-          deployment_host: "HOST", app_name: "APP", branch_name?: true,
+          deployment_host: "HOST", app_name: "APP", remote_name: "APP", branch_name?: true,
           branch_name: :head, tag_name: nil,
           system_caller: system_caller
         )
@@ -201,7 +214,7 @@ describe Paratrooper::SourceControl do
     context "when branch_name is the string HEAD" do
       it 'pushes HEAD' do
         config = instance_double(Paratrooper::Configuration, force_push: false,
-          deployment_host: "HOST", app_name: "APP", branch_name?: true,
+          deployment_host: "HOST", app_name: "APP", remote_name: "APP", branch_name?: true,
           branch_name: "HEAD", tag_name: nil,
           system_caller: system_caller
         )
@@ -217,7 +230,7 @@ describe Paratrooper::SourceControl do
       it "issues command to forcefully push to remote" do
         config = instance_double(Paratrooper::Configuration,
           system_caller: system_caller, force_push: true,
-          deployment_host: 'HOST', app_name: 'APP', branch_name?: false,
+          deployment_host: "HOST", app_name: "APP", remote_name: "APP", branch_name?: false,
           tag_name: nil
         )
         source_control = described_class.new(config)
@@ -231,7 +244,7 @@ describe Paratrooper::SourceControl do
     context "when branch_name is available" do
       it "pushes branch_name" do
         config = instance_double(Paratrooper::Configuration, force_push: false,
-          deployment_host: "HOST", app_name: "APP", branch_name?: true,
+          deployment_host: "HOST", app_name: "APP", remote_name: "APP", branch_name?: true,
           branch_name: "BRANCH_NAME", tag_name: nil,
           system_caller: system_caller
         )
@@ -246,7 +259,7 @@ describe Paratrooper::SourceControl do
     context "when no reference is defined" do
       it "pushes HEAD" do
         config = instance_double(Paratrooper::Configuration, force_push: false,
-          deployment_host: "HOST", app_name: "APP", branch_name?: false,
+          deployment_host: "HOST", app_name: "APP", remote_name: "APP", branch_name?: false,
           tag_name: nil, system_caller: system_caller
         )
         source_control = described_class.new(config)


### PR DESCRIPTION
Previously the app name was always used as the remote name too. Cases exist when this needs to be separated.